### PR TITLE
fix: change header to lowercase

### DIFF
--- a/packages/enclave/src/middlewares/sdkInjector.ts
+++ b/packages/enclave/src/middlewares/sdkInjector.ts
@@ -10,8 +10,8 @@ export default (req: express.Request, resp: express.Response, next: express.Next
     }
   }
 
-  if (req.headers['X-Henesis-Secret']) {
-    secret = req.headers['X-Henesis-Secret'];
+  if (req.headers['x-henesis-secret']) {
+    secret = req.headers['x-henesis-secret'];
   }
 
   req.sdk = new SDK({


### PR DESCRIPTION
express request 헤더를 까보면 이렇게 들어옴. 즉 header key가 전부 소문자로 변환되어 들어옴. 

{ 'x-henesis-secret': 'ENEBtmucI1UDQcZThHs5nKgfnM4acnhVwbUzF6YQv4w=',
  authorization:
   'Bearer eyJhbGciOiJIUzUxMiJ9.eyJlbWFpbCI6InRlc3RAaGlibG9ja3MuaW8iLCJpZCI6ImRlYjhmZDVmOWExNWZhZDQ5Y2UxZDM2ODI3N2RlMWY4IiwidHlwZSI6IkxPTkciLCJpc3MiOiJ3YWxsZXQtZGV2IiwiaWF0IjoxNTg2NDUwNTU5LCJleHAiOjM3NTg2NDUwNTU5fQ.mkn08qyhZPSoEHsQcxV5nhVNKD4d-XppSz5ZLuVF2gmUqkI3Lyu_Vr8H0gC5uuFdVW346YTZU0ImZBjmgmnRgA',
  'user-agent': 'PostmanRuntime/7.24.1',
  accept: '*/*',
  'cache-control': 'no-cache',
  'postman-token': 'ce0d0e05-6b9c-4b79-8e66-7ff966bea82f',
  host: 'localhost:3000',
  'accept-encoding': 'gzip, deflate, br',
  connection: 'keep-alive' }
