### PR TITLE
fix: added txId in event, createdAt at transactions

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -5,6 +5,8 @@ import { BNConverter, toSnakeCase } from './utils';
 import { BlockchainType } from './blockchain';
 
 export interface Event {
+  id: number;
+  transactionId: string;
   createdAt: string;
   status: EventStatusType;
   toAddress: string;

--- a/packages/core/src/transactions.ts
+++ b/packages/core/src/transactions.ts
@@ -14,6 +14,7 @@ export interface Transaction {
   signedMultiSigPayload: SignedMultiSigPayload;
   rawTransaction: RawTransaction;
   status: TransactionStatus;
+  createdAt: string;
 }
 
 export interface TransactionPaginationOptions extends PaginationOptions {


### PR DESCRIPTION
wallet api에는 있지만, enclave api에는 없는 값 2개(event의 txId, transaction의 createdAt) 추가했습니다