### PR TITLE
fix: fix integration_test github action with README.md badge

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -19,7 +19,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2-beta
         with:
           node-version: '10'
           check-latest: true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Henesis Wallet SDK
+
+![Integration Test Action](https://github.com/HAECHI-LABS/henesis-wallet-sdk/workflows/Integration%20Test%20Action/badge.svg) [![Build Status](https://travis-ci.com/HAECHI-LABS/henesis-wallet-sdk.svg?branch=master)](https://travis-ci.com/HAECHI-LABS/henesis-wallet-sdk)
+
+

--- a/packages/core/__integration__/btc/btc.integration.ts
+++ b/packages/core/__integration__/btc/btc.integration.ts
@@ -5,8 +5,8 @@ import BN from "bn.js";
 import { retryAsync } from "ts-retry";
 import { TransferStatus } from "../../src/btc/transfers";
 
-describe.skip("BTC integration tests", () => {
-  const maxTimeout = 20 * 60 * 1000;
+describe("BTC integration tests", () => {
+  const maxTimeout = 30 * 60 * 1000;
   jest.setTimeout(maxTimeout);
   const config = require("../dev.config.json");
   const sdkAdmin = new SDK({
@@ -40,17 +40,18 @@ describe.skip("BTC integration tests", () => {
         new BN(1),
         config.btc.password
       );
-
+      console.log(transfer);
       try {
         const result = await retryAsync(
           async () => {
             const confirmedTransfer = await sdkAdmin.btc.transfers.getTransfer(transfer.id);
+            console.log(confirmedTransfer.status);
             if (confirmedTransfer.status == TransferStatus.PENDING || confirmedTransfer.status == TransferStatus.MINED) {
               throw new Error("error");
             }
             return confirmedTransfer;
           },
-          { delay: 10000, maxTry: 120 } // 20min
+          { delay: 10000, maxTry: 180 } // 30min
         );
         expect(result.status).toEqual(TransferStatus.CONFIRMED);
       } catch (e) {

--- a/packages/core/__tests__/btc/wallet.spec.ts
+++ b/packages/core/__tests__/btc/wallet.spec.ts
@@ -120,6 +120,7 @@ describe.skip('BtcMasterWallet', () => {
       const wallet = await wallets.getWallet(
         '61898f8d5b4c69bbd7f7b9216e5d5bff',
       );
+
     });
   });
 });


### PR DESCRIPTION
# Changelist

## FIX: BTC transfer 테스트 설정 변경

- **TIMEOUT 시간을 20분에서 30분으로 증가**: block confirm이 되려면 기본 20분 정도 걸리는데 watcher가 2 confirm의 블럭을 가져오는데 20분이 넘을 때가 있음
- **transfer 로그 추가**: 테스트 도중 현재 transfer가 제대로 진행되고 있는지 확인할 수 있음

## FIX: Github Action `integration_test.yml` 설정 변경
https://github.com/actions/setup-node/issues/172 이슈와 관련해서 현재 `actions/setup-node@v2-beta` 태그를 사용하여 플러그인을 사용하여야함
