### PR TITLE
fix: fix async test by calling done() func

### DIFF
--- a/packages/core/__integration__/btc/btc.integration.ts
+++ b/packages/core/__integration__/btc/btc.integration.ts
@@ -6,7 +6,7 @@ import { retryAsync } from "ts-retry";
 import { TransferStatus } from "../../src/btc/transfers";
 
 describe("BTC integration tests", () => {
-  const maxTimeout = 30 * 60 * 1000;
+  const maxTimeout = 40 * 60 * 1000;
   jest.setTimeout(maxTimeout);
   const config = require("../dev.config.json");
   const sdkAdmin = new SDK({
@@ -51,9 +51,10 @@ describe("BTC integration tests", () => {
             }
             return confirmedTransfer;
           },
-          { delay: 10000, maxTry: 180 } // 30min
+          { delay: 10000, maxTry: 240 } // 40min
         );
         expect(result.status).toEqual(TransferStatus.CONFIRMED);
+        done();
       } catch (e) {
         done.fail("transfer status should be confirmed but pending");
       }

--- a/packages/core/__integration__/btc/btc.integration.ts
+++ b/packages/core/__integration__/btc/btc.integration.ts
@@ -40,12 +40,10 @@ describe("BTC integration tests", () => {
         new BN(1),
         config.btc.password
       );
-      console.log(transfer);
       try {
         const result = await retryAsync(
           async () => {
             const confirmedTransfer = await sdkAdmin.btc.transfers.getTransfer(transfer.id);
-            console.log(confirmedTransfer.status);
             if (confirmedTransfer.status == TransferStatus.PENDING || confirmedTransfer.status == TransferStatus.MINED) {
               throw new Error("error");
             }
@@ -54,10 +52,11 @@ describe("BTC integration tests", () => {
           { delay: 10000, maxTry: 240 } // 40min
         );
         expect(result.status).toEqual(TransferStatus.CONFIRMED);
-        done();
       } catch (e) {
+        console.log(transfer.id);
         done.fail("transfer status should be confirmed but pending");
       }
+      done();
     });
   });
 });

--- a/packages/core/__integration__/eth/eth.integration.ts
+++ b/packages/core/__integration__/eth/eth.integration.ts
@@ -7,7 +7,7 @@ import { TransferStatus } from "../../src/btc/transfers";
 import { ValueTransferEventDTO as EthValueTransferEventDTO } from "../../src/__generate__/eth";
 
 describe("ETH integration tests", () => {
-  const maxTimeout = 5 * 60 * 1000; // min 5
+  const maxTimeout = 10 * 60 * 1000; // min 10
   jest.setTimeout(maxTimeout);
   const config = require("../dev.config.json");
   const sdkAdmin = new SDK({
@@ -38,7 +38,7 @@ describe("ETH integration tests", () => {
             }
             return activeMasterWallet;
           },
-          { delay: 10000, maxTry: 30 } // 5 min
+          { delay: 10000, maxTry: 60 } // 10 min
         );
         expect(result.getData().status).toEqual(WalletStatus.ACTIVE);
       } catch (e) {
@@ -77,7 +77,7 @@ describe("ETH integration tests", () => {
             }
             return confirmedTransferEvents;
           },
-          { delay: 10000, maxTry: 30 } // 5 min
+          { delay: 10000, maxTry: 60 } // 10 min
         );
         expect(result.results[0].status).toEqual(TransferStatus.CONFIRMED);
       } catch (e) {
@@ -114,7 +114,7 @@ describe("ETH integration tests", () => {
             }
             return confirmedTransferEvents;
           },
-          { delay: 10000, maxTry: 30 } // 5 min
+          { delay: 10000, maxTry: 60 } // 10 min
         );
         expect(result.results[0].status).toEqual(TransferStatus.CONFIRMED);
       } catch (e) {
@@ -141,7 +141,7 @@ describe("ETH integration tests", () => {
             }
             return activeUserWallet;
           },
-          { delay: 10000, maxTry: 30 } // 5 min
+          { delay: 10000, maxTry: 60 } // 10 min
         );
         expect(result.getData().status).toEqual(WalletStatus.ACTIVE);
       } catch (e) {
@@ -181,13 +181,14 @@ describe("ETH integration tests", () => {
             }
             return confirmedTransferEvents;
           },
-          { delay: 10000, maxTry: 30 } // 5 min
+          { delay: 10000, maxTry: 60 } // 10 min
         );
         expect(result.results[0].status).toEqual(TransferStatus.CONFIRMED);
       } catch (e) {
         console.log(transfer.id);
         done.fail("status of value transfer event should be confirmed");
       }
+      done();
     });
 
     it("should erc20 transfer from user wallet", async (done) => {
@@ -219,13 +220,14 @@ describe("ETH integration tests", () => {
             }
             return confirmedTransferEvents;
           },
-          { delay: 10000, maxTry: 30 } // 5 min
+          { delay: 10000, maxTry: 60 } // 10 min
         );
         expect(result.results[0].status).toEqual(TransferStatus.CONFIRMED);
       } catch (e) {
         console.log(transfer.id);
         done.fail("status of value transfer event should be confirmed");
       }
+      done();
     });
   });
 });

--- a/packages/core/__integration__/klay/klay.integration.ts
+++ b/packages/core/__integration__/klay/klay.integration.ts
@@ -227,6 +227,7 @@ describe("Klay integration tests", () => {
         console.log(transfer.id);
         done.fail("status of value transfer event should be confirmed");
       }
+      done();
     });
   });
 });


### PR DESCRIPTION
# Changelist

## FIX: BTC transfer 테스트 설정 변경

- **TIMEOUT 시간을 30분에서 40분으로 증가**: 테스트넷 환경에 따라 30분도 부족할 때가 있음

## FIX: 비동기 테스트에 `done()` 함수를 호출하지 않아 테스트가 끝나지 않음
BTC 테스트에서 트랜잭션이 confirmed되었다면 `done()`을 호출하여 테스트 종료

