### PR TITLE
fix: fixed api client request data

### DIFF
--- a/packages/core/src/httpClient.ts
+++ b/packages/core/src/httpClient.ts
@@ -78,7 +78,7 @@ export class HttpClient {
     const client = this.makeClient();
     client.defaults.baseURL = removePrefixApi(client.defaults.baseURL);
     client.interceptors.request.use((config) => {
-      if(config.data) {
+      if (config.data) {
         const dataObj = JSON.parse(config.data);
         config.data = ObjectConverter.toSnakeCase(dataObj);
       }

--- a/packages/core/src/httpClient.ts
+++ b/packages/core/src/httpClient.ts
@@ -78,7 +78,8 @@ export class HttpClient {
     const client = this.makeClient();
     client.defaults.baseURL = removePrefixApi(client.defaults.baseURL);
     client.interceptors.request.use((config) => {
-      config.data = ObjectConverter.toSnakeCase(config.data);
+      const dataObj = JSON.parse(config.data);
+      config.data = ObjectConverter.toSnakeCase(dataObj);
       return config;
     });
 

--- a/packages/core/src/httpClient.ts
+++ b/packages/core/src/httpClient.ts
@@ -78,8 +78,10 @@ export class HttpClient {
     const client = this.makeClient();
     client.defaults.baseURL = removePrefixApi(client.defaults.baseURL);
     client.interceptors.request.use((config) => {
-      const dataObj = JSON.parse(config.data);
-      config.data = ObjectConverter.toSnakeCase(dataObj);
+      if(config.data) {
+        const dataObj = JSON.parse(config.data);
+        config.data = ObjectConverter.toSnakeCase(dataObj);
+      }
       return config;
     });
 


### PR DESCRIPTION
code gen으로 api 호출시 to snake case가 오작동하고 있었음을 인지했었습니다. 
name 파람만 넘겼을 시엔 snake case가 동작하지 않았지만 otpCode 경우엔 동작하고 있지 않았습니다.


src/__generate__/btc/api.ts 1591 line
```
localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
            const needsSerialization = (typeof createDepositAddressRequest !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
            localVarRequestOptions.data =  needsSerialization ? JSON.stringify(createDepositAddressRequest !== undefined ? createDepositAddressRequest : {}) : (createDepositAddressRequest || "");
```

해당 부분에서 JSON.stringify 하기에 parsing하여 toSnakeCase하는 코드를 추가하였습니다.
```
  client.interceptors.request.use((config) => {
      const dataObj = JSON.parse(config.data);
      config.data = ObjectConverter.toSnakeCase(dataObj);
      return config;
    });
```