### PR TITLE
feat: add aggregated amount to get master wallet balance

### DIFF
--- a/packages/core/src/eth/wallet.ts
+++ b/packages/core/src/eth/wallet.ts
@@ -27,6 +27,7 @@ import {
   NonceDTO,
   UserWalletDTO,
   BalanceDTO,
+  MasterWalletBalanceDTO,
   PaginationUserWalletDTO,
   MasterWalletDTO,
   ApproveWithdrawalApprovalRequest,
@@ -479,9 +480,9 @@ export class EthMasterWallet extends EthLikeWallet {
 
   async getBalance(flag?: boolean, symbol?: string): Promise<Balance[]> {
     const queryString: string = makeQueryString({ flag, symbol });
-    const balances = await this.client.get<NoUndefinedField<BalanceDTO>[]>(
-      `${this.baseUrl}/balance${queryString ? `?${queryString}` : ""}`
-    );
+    const balances = await this.client.get<
+      NoUndefinedField<MasterWalletBalanceDTO>[]
+    >(`${this.baseUrl}/balance${queryString ? `?${queryString}` : ""}`);
 
     return balances.map((balance) => ({
       coinId: balance.coinId,
@@ -492,6 +493,9 @@ export class EthMasterWallet extends EthLikeWallet {
         String(balance.spendableAmount)
       ),
       name: balance.name,
+      aggregatedAmount: BNConverter.hexStringToBN(
+        String(balance.aggregatedAmount)
+      ),
     }));
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,7 @@ export interface Balance {
   spendableAmount?: BN;
   name: string;
   symbol: string;
+  aggregatedAmount?: BN;
 }
 
 export interface Key {

--- a/packages/enclave/src/controllers/eth/wallets.controller.ts
+++ b/packages/enclave/src/controllers/eth/wallets.controller.ts
@@ -15,9 +15,14 @@ import { BNConverter, SDK } from "@haechi-labs/henesis-wallet-core";
 import AbstractController from "../controller";
 import { Controller } from "../../types";
 
-interface BalanceResponse extends Omit<Balance, "amount" | "spendableAmount"> {
+interface BalanceResponse
+  extends Omit<Balance, "amount" | "spendableAmount" | "aggregatedAmount"> {
   amount: string;
   spendableAmount?: string;
+}
+
+interface MasterWalletBalanceResponse extends BalanceResponse {
+  aggregatedAmount: string;
 }
 
 interface Nonce {
@@ -249,7 +254,7 @@ export default class WalletsController
 
   private async getMasterWalletBalance(
     req: express.Request
-  ): Promise<BalanceResponse[]> {
+  ): Promise<MasterWalletBalanceResponse[]> {
     const masterWallet = await req.sdk.eth.wallets.getMasterWallet(
       req.params.masterWalletId
     );

--- a/packages/enclave/src/controllers/klay/wallets.controller.ts
+++ b/packages/enclave/src/controllers/klay/wallets.controller.ts
@@ -15,9 +15,14 @@ import {
   Pagination,
 } from "@haechi-labs/henesis-wallet-core/lib/types";
 
-interface BalanceResponse extends Omit<Balance, "amount" | "spendableAmount"> {
+interface BalanceResponse
+  extends Omit<Balance, "amount" | "spendableAmount" | "aggregatedAmount"> {
   amount: string;
   spendableAmount?: string;
+}
+
+interface MasterWalletBalanceResponse extends BalanceResponse {
+  aggregatedAmount: string;
 }
 
 interface Nonce {
@@ -239,7 +244,7 @@ export default class WalletsController
 
   private async getMasterWalletBalance(
     req: express.Request
-  ): Promise<BalanceResponse[]> {
+  ): Promise<MasterWalletBalanceResponse[]> {
     const masterWallet = await req.sdk.klay.wallets.getMasterWallet(
       req.params.masterWalletId
     );


### PR DESCRIPTION
`aggregatedAmount`: (master wallet amount) + (sum of each user wallet amount under that master wallet)

example)

```
master wallet A
|_ user wallet aa
|_ user wallet bb

A has 10 ETH
aa has 5 ETH
bb has 1 ETH
```
`master wallet A`'s amount 10 ETH + `user wallets` amount 6 ETH (`user wallet aa`'s amount 5 ETH + `user wallet bb`'s amount 1 ETH)
So, A's `amount` is 10 ETH and `aggregatedAmount` is 16 ETH. 