### PR TITLE
feat: hot reload, nest swagger plugin enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 packages/*/lib
 .idea
 .DS_Store
+dist

--- a/packages/enclave/nest-cli.json
+++ b/packages/enclave/nest-cli.json
@@ -1,0 +1,15 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "classValidatorShim": false,
+          "introspectComments": true
+        }
+      }
+    ]
+  }
+}

--- a/packages/enclave/nodemon.json
+++ b/packages/enclave/nodemon.json
@@ -1,6 +1,0 @@
-{
-  "watch": ["src"],
-  "ext": "ts",
-  "ignore": ["src/**/*.spec.ts"],
-  "exec": "ts-node ./src/index.ts"
-}

--- a/packages/enclave/package.json
+++ b/packages/enclave/package.json
@@ -10,14 +10,14 @@
     "lib"
   ],
   "scripts": {
-    "start": "nodemon",
-    "start:local": "cross-env NODE_ENV=local nodemon",
-    "start:dev": "cross-env NODE_ENV=development nodemon",
-    "start:test": "cross-env NODE_ENV=test nodemon",
+    "start": "nest start",
+    "start:local": "cross-env NODE_ENV=local nest start --watch",
+    "start:dev": "cross-env NODE_ENV=development nest start --watch",
+    "start:test": "cross-env NODE_ENV=test nest start --watch",
     "lint:fix": "eslint 'src/**/*.ts' --fix",
     "test": "jest --passWithNoTests",
     "type-check": "tsc --noEmit",
-    "build": "rm -rf ./lib && tsc",
+    "build": "rm -rf ./lib && nest build",
     "build:windows": "npm run preBuild:windows && mkdir lib && tsc",
     "eslint": "./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx ./src",
     "eslint:fix": "./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx ./src --fix",
@@ -45,6 +45,7 @@
     "ts-node": "^8.6.2"
   },
   "devDependencies": {
+    "@nestjs/cli": "7.6.0",
     "@types/express": "^4.17.2",
     "@types/jest": "^24.0.15",
     "@types/lru-cache": "^5.1.0",
@@ -59,11 +60,15 @@
     "eslint-plugin-prettier": "^3.1.3",
     "jest": "^24.8.0",
     "jest-extended": "^0.11.1",
+    "ts-loader": "8.1.0",
+    "webpack": "5.28.0",
+    "webpack-cli": "4.6.0",
     "nock": "^12.0.3",
-    "nodemon": "^2.0.2",
     "prettier": "^2.0.5",
+    "run-script-webpack-plugin": "0.0.11",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "webpack-node-externals": "2.5.2"
   },
   "jest": {
     "transform": {

--- a/packages/enclave/src/v2/api.v2.module.ts
+++ b/packages/enclave/src/v2/api.v2.module.ts
@@ -1,11 +1,9 @@
 import { Module } from "@nestjs/common";
 import { KlayModule } from "./klay/klay.module";
-import VersionController from "./version/version.controller";
 import { EthModule } from "./eth/eth.module";
 import { BtcModule } from "./btc/btc.module";
 
 @Module({
   imports: [KlayModule, EthModule, BtcModule],
-  controllers: [VersionController],
 })
 export class ApiV2Module {}

--- a/packages/enclave/src/v2/eth/dto/coin.dto.ts
+++ b/packages/enclave/src/v2/eth/dto/coin.dto.ts
@@ -1,2 +1,9 @@
 // todo: define
-export class CoinDTO {}
+export class CoinDTO {
+  /**
+   * 코인 id
+   * @example 2
+   * @requires false
+   */
+  coinId: string;
+}

--- a/packages/enclave/tsconfig.build.json
+++ b/packages/enclave/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+  },
+}

--- a/packages/enclave/tsconfig.json
+++ b/packages/enclave/tsconfig.json
@@ -6,12 +6,14 @@
     "outDir": "./lib",
     "rootDir": "./src",
     "allowJs": true,
+    "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "declaration": true
   },
-  "include": ["./src"]
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
- hot reloading 설정하였습니다. nodemon보다 nest cli를 이용하는게 더 빠른 것 같아서 설정하였습니다. 개발 환경에서 아래와 같이 실행하면 됩니다
```
npm run start:dev
```
- nestjs/swagger plugin이 있어서 enable 시켰습니다.(https://docs.nestjs.com/openapi/cli-plugin) 이제 @ApiProperty 어노테이션이 없어도 swagger로 잘 뽑힙니다.
```
//now!!
/**
 * A list of user's roles
 * @example ['admin']
 */
roles: RoleEnum[] = [];

//before
/**
 * A list of user's roles
 * @example ['admin']
 */
@ApiProperty({
  description: `A list of user's roles`,
  example: ['admin'],
})
roles: RoleEnum[] = [];

```