### PR TITLE
fix: use v3 API's URL in the pagination example

### DIFF
--- a/packages/api-proxy/src/v3/eth/dto/pagination.dto.ts
+++ b/packages/api-proxy/src/v3/eth/dto/pagination.dto.ts
@@ -10,8 +10,8 @@ import {
 } from "./transaction.dto";
 
 export const EXAMPLE_ETHEREUM_PAGINATION_METADATA: PaginationMetadata = {
-  nextUrl: "http://localhost:3000/api/v2/eth/value-transfer-events?page=2",
-  previousUrl: "http://localhost:3000/api/v2/eth/value-transfer-events?page=1",
+  nextUrl: "http://localhost:3000/api/v3/ethereum/transfers?page=2",
+  previousUrl: "http://localhost:3000/api/v3/ethereum/transfers?page=1",
   totalCount: 5,
 };
 


### PR DESCRIPTION
v3의 페이지 metadata가 v2의 API URL을 쓰고있어서 바꾸었습니다.